### PR TITLE
Deprecate constructors of `Pressures`, etc., from `String`s

### DIFF
--- a/src/EquationOfStateWorkflow/Config.jl
+++ b/src/EquationOfStateWorkflow/Config.jl
@@ -26,7 +26,6 @@ using ...Express: Calculation, Action, myuparse
         return new(values, unit)
     end
 end
-Pressures(values::AbstractString, unit = "GPa") = Pressures(eval(Meta.parse(values)), unit)
 
 @option "volumes" struct Volumes
     values::AbstractVector
@@ -38,7 +37,6 @@ Pressures(values::AbstractString, unit = "GPa") = Pressures(eval(Meta.parse(valu
         return new(values, unit)
     end
 end
-Volumes(values::AbstractString, unit = "bohr^3") = Volumes(eval(Meta.parse(values)), unit)
 
 @option struct TrialEquationOfState
     type::String

--- a/src/EquationOfStateWorkflow/Config.jl
+++ b/src/EquationOfStateWorkflow/Config.jl
@@ -14,9 +14,9 @@ using EquationsOfStateOfSolids:
     Vinet
 using Formatting: sprintf1
 
-using ...Express: Calculation, Action, myuparse
+using ...Express: Calculation, Action, UnitfulVector, myuparse
 
-@option "pressures" struct Pressures
+@option "pressures" struct Pressures <: UnitfulVector
     values::AbstractVector
     unit::String
     function Pressures(values, unit = "GPa")
@@ -27,7 +27,7 @@ using ...Express: Calculation, Action, myuparse
     end
 end
 
-@option "volumes" struct Volumes
+@option "volumes" struct Volumes <: UnitfulVector
     values::AbstractVector
     unit::String
     function Volumes(values, unit = "bohr^3")

--- a/src/Express.jl
+++ b/src/Express.jl
@@ -48,7 +48,7 @@ end
 abstract type UnitfulVector end
 
 function current_software end
-convert_to_option(::Type{UnitfulVector}, ::Type{AbstractVector}, s) = eval(Meta.parse(s))
+convert_to_option(::Type{<:UnitfulVector}, ::Type{AbstractVector}, s) = eval(Meta.parse(s))
 
 # include("SelfConsistentField.jl")
 # include("BandStructure.jl")

--- a/src/Express.jl
+++ b/src/Express.jl
@@ -6,6 +6,8 @@ using Unitful: uparse
 import Unitful
 import UnitfulAtomic
 
+import Configurations: convert_to_option
+
 myuparse(str::AbstractString) =
     uparse(filter(!isspace, str); unit_context = [Unitful, UnitfulAtomic])
 myuparse(num::Number) = num  # FIXME: this might be error-prone!
@@ -43,8 +45,10 @@ function buildworkflow(file)
     mod = whichmodule(config["workflow"])
     return mod.buildworkflow(file)
 end
+abstract type UnitfulVector end
 
 function current_software end
+convert_to_option(::Type{UnitfulVector}, ::Type{AbstractVector}, s) = eval(Meta.parse(s))
 
 # include("SelfConsistentField.jl")
 # include("BandStructure.jl")

--- a/src/PhononWorkflow/Config.jl
+++ b/src/PhononWorkflow/Config.jl
@@ -33,13 +33,11 @@ end
     values::AbstractVector
     unit::String = "GPa"
 end
-Pressures(values::AbstractString, unit = "GPa") = Pressures(eval(Meta.parse(values)), unit)
 
 @option "volumes" struct Volumes
     values::AbstractVector
     unit::String = "bohr^3"
 end
-Volumes(values::AbstractString, unit = "bohr^3") = Volumes(eval(Meta.parse(values)), unit)
 
 @option struct Directories
     root::String = pwd()

--- a/src/PhononWorkflow/Config.jl
+++ b/src/PhononWorkflow/Config.jl
@@ -4,7 +4,7 @@ using AbInitioSoftwareBase.Commands: CommandConfig
 using Configurations: from_dict, @option
 using Formatting: sprintf1
 using Unitful: ustrip
-using ...Express: Action, myuparse
+using ...Express: Action, UnitfulVector, myuparse
 using ..PhononWorkflow: Scf, Dfpt, RealSpaceForceConstants, LatticeDynamics
 
 @option struct Template
@@ -29,12 +29,12 @@ using ..PhononWorkflow: Scf, Dfpt, RealSpaceForceConstants, LatticeDynamics
     end
 end
 
-@option "pressures" struct Pressures
+@option "pressures" struct Pressures <: UnitfulVector
     values::AbstractVector
     unit::String = "GPa"
 end
 
-@option "volumes" struct Volumes
+@option "volumes" struct Volumes <: UnitfulVector
     values::AbstractVector
     unit::String = "bohr^3"
 end

--- a/src/QuasiHarmonicApproxWorkflow/Config.jl
+++ b/src/QuasiHarmonicApproxWorkflow/Config.jl
@@ -17,7 +17,6 @@ import Configurations: convert_to_option
         return new(values, unit)
     end
 end
-Pressures(values::AbstractString, unit = "GPa") = Pressures(eval(Meta.parse(values)), unit)
 
 @option "temperatures" struct Temperatures
     values::AbstractVector
@@ -27,8 +26,6 @@ Pressures(values::AbstractString, unit = "GPa") = Pressures(eval(Meta.parse(valu
         return new(values, unit)
     end
 end
-Temperatures(values::AbstractString, unit = "K") =
-    Temperatures(eval(Meta.parse(values)), unit)
 
 @option struct Thermo
     F::Bool = true

--- a/src/QuasiHarmonicApproxWorkflow/Config.jl
+++ b/src/QuasiHarmonicApproxWorkflow/Config.jl
@@ -5,9 +5,9 @@ using Configurations: from_dict, @option
 using Unitful: ustrip, @u_str
 using ...Express: Action, myuparse
 
-@option "pressures" struct Pressures
 import Configurations: convert_to_option
 
+@option struct Pressures
     values::AbstractVector
     unit::String
     function Pressures(values, unit = "GPa")
@@ -18,7 +18,7 @@ import Configurations: convert_to_option
     end
 end
 
-@option "temperatures" struct Temperatures
+@option struct Temperatures
     values::AbstractVector
     unit::String
     function Temperatures(values, unit = "K")

--- a/src/QuasiHarmonicApproxWorkflow/Config.jl
+++ b/src/QuasiHarmonicApproxWorkflow/Config.jl
@@ -6,6 +6,8 @@ using Unitful: ustrip, @u_str
 using ...Express: Action, myuparse
 
 @option "pressures" struct Pressures
+import Configurations: convert_to_option
+
     values::AbstractVector
     unit::String
     function Pressures(values, unit = "GPa")
@@ -146,5 +148,8 @@ function (x::ExpandConfig)(config::AbstractDict)
         q_points = config.q_points,
     )
 end
+
+convert_to_option(::Type{Temperatures}, ::Type{AbstractVector}, s) = eval(Meta.parse(s))
+convert_to_option(::Type{Pressures}, ::Type{AbstractVector}, s) = eval(Meta.parse(s))
 
 end

--- a/src/QuasiHarmonicApproxWorkflow/Config.jl
+++ b/src/QuasiHarmonicApproxWorkflow/Config.jl
@@ -3,11 +3,9 @@ module Config
 using AbInitioSoftwareBase: save, load, parentdir
 using Configurations: from_dict, @option
 using Unitful: ustrip, @u_str
-using ...Express: Action, myuparse
+using ...Express: Action, UnitfulVector, myuparse
 
-import Configurations: convert_to_option
-
-@option struct Pressures
+@option struct Pressures <: UnitfulVector
     values::AbstractVector
     unit::String
     function Pressures(values, unit = "GPa")
@@ -18,7 +16,7 @@ import Configurations: convert_to_option
     end
 end
 
-@option struct Temperatures
+@option struct Temperatures <: UnitfulVector
     values::AbstractVector
     unit::String
     function Temperatures(values, unit = "K")
@@ -145,8 +143,5 @@ function (x::ExpandConfig)(config::AbstractDict)
         q_points = config.q_points,
     )
 end
-
-convert_to_option(::Type{Temperatures}, ::Type{AbstractVector}, s) = eval(Meta.parse(s))
-convert_to_option(::Type{Pressures}, ::Type{AbstractVector}, s) = eval(Meta.parse(s))
 
 end


### PR DESCRIPTION
Extend `Configurations.convert_to_option` for `Temperatures` & `Pressures` from `String`