### PR TITLE
Deprecate `getpotentials` & `getpseudodir`

### DIFF
--- a/src/ConvergenceTestWorkflow/actions.jl
+++ b/src/ConvergenceTestWorkflow/actions.jl
@@ -88,14 +88,12 @@ struct TestConvergence{T} <: Action{T} end
 function buildjob(x::TestConvergence{T}, cfgfile) where {T}
     dict = load(cfgfile)
     config = ExpandConfig{T}()(dict)
-    return AtomicJob(
-        function ()
-            data = GetData{T}()(last.(config.files))
-            saved = Dict("results" => (ustrip ∘ last).(data))
-            save(config.save_raw, saved)
-            return x(data)
-        end,
-    )
+    return AtomicJob(function ()
+        data = GetData{T}()(last.(config.files))
+        saved = Dict("results" => (ustrip ∘ last).(data))
+        save(config.save_raw, saved)
+        return x(data)
+    end)
 end
 
 struct LogMsg{T} <: Action{T} end

--- a/src/ConvergenceTestWorkflow/actions.jl
+++ b/src/ConvergenceTestWorkflow/actions.jl
@@ -1,5 +1,5 @@
 using AbInitioSoftwareBase: save, load, extension
-using AbInitioSoftwareBase.Inputs: Input, writetxt
+using AbInitioSoftwareBase.Inputs: Input, writetxt, getpseudodir, getpotentials
 using Dates: now, format
 using Logging: with_logger, current_logger
 using Pseudopotentials: download_potential
@@ -28,10 +28,6 @@ function buildjob(x::DownloadPotentials{T}, cfgfile) where {T}
     config = ExpandConfig{T}()(dict)
     return AtomicJob(() -> x(config.template))
 end
-
-function getpseudodir end
-
-function getpotentials end
 
 struct MakeInput{T} <: Action{T} end
 function (x::MakeInput)(file, template::Input, args...)

--- a/src/EquationOfStateWorkflow/actions.jl
+++ b/src/EquationOfStateWorkflow/actions.jl
@@ -1,5 +1,5 @@
 using AbInitioSoftwareBase: save, load, extension
-using AbInitioSoftwareBase.Inputs: Input, writetxt
+using AbInitioSoftwareBase.Inputs: Input, writetxt, getpseudodir, getpotentials
 using Dates: now, format
 using EquationsOfStateOfSolids:
     EquationOfStateOfSolids, EnergyEquation, PressureEquation, Parameters, getparam
@@ -32,10 +32,6 @@ function buildjob(x::DownloadPotentials{T}, cfgfile) where {T}
     config = ExpandConfig{T}()(dict)
     return AtomicJob(() -> x(config.template))
 end
-
-function getpseudodir end
-
-function getpotentials end
 
 struct MakeInput{T} <: Action{T} end
 function (x::MakeInput)(file, template::Input, args...)

--- a/src/PhononWorkflow/actions.jl
+++ b/src/PhononWorkflow/actions.jl
@@ -1,5 +1,5 @@
 using AbInitioSoftwareBase: load
-using AbInitioSoftwareBase.Inputs: Input, writetxt
+using AbInitioSoftwareBase.Inputs: Input, writetxt, getpseudodir, getpotentials
 using Dates: now, format
 using Logging: with_logger, current_logger
 using Pseudopotentials: download_potential
@@ -28,10 +28,6 @@ function buildjob(x::DownloadPotentials{T}, cfgfile) where {T}
     config = ExpandConfig{T}()(dict)
     return AtomicJob(() -> x(config.template))
 end
-
-function getpseudodir end
-
-function getpotentials end
 
 struct MakeInput{T} <: Action{T} end
 function (x::MakeInput{T})(


### PR DESCRIPTION
They are implemented by AbInitioSoftwareBase.jl