### PR TITLE
Revert some bad decisions in #202

### DIFF
--- a/src/ConvergenceTestWorkflow/Config.jl
+++ b/src/ConvergenceTestWorkflow/Config.jl
@@ -3,9 +3,8 @@ module Config
 using AbInitioSoftwareBase.Commands: CommandConfig
 using Configurations: from_dict, @option
 using Formatting: sprintf1
-using Unitful: @u_str
 
-using ...Express: Calculation, Action, UnitfulVector
+using ...Express: Calculation, Action, UnitfulVector, myuparse
 
 @option "ecutwfc" struct CutoffEnergies <: UnitfulVector
     values::AbstractVector
@@ -65,7 +64,7 @@ end
 
 struct ExpandConfig{T} <: Action{T} end
 function (::ExpandConfig)(energies::CutoffEnergies)
-    unit = @u_str(energies.unit)
+    unit = myuparse(energies.unit)
     return energies.values .* unit
 end
 function (::ExpandConfig)(x::MonkhorstPackGrids)

--- a/src/EquationOfStateWorkflow/Config.jl
+++ b/src/EquationOfStateWorkflow/Config.jl
@@ -13,9 +13,8 @@ using EquationsOfStateOfSolids:
     PoirierTarantola4th,
     Vinet
 using Formatting: sprintf1
-using Unitful: @u_str
 
-using ...Express: Calculation, Action, UnitfulVector
+using ...Express: Calculation, Action, UnitfulVector, myuparse
 
 @option "pressures" struct Pressures <: UnitfulVector
     values::AbstractVector
@@ -109,10 +108,10 @@ function (::ExpandConfig)(trial_eos::TrialEquationOfState)
     else
         error("unsupported eos name `\"$type\"`!")
     end
-    return T(map(@u_str, trial_eos.values)...)
+    return T(map(myuparse, trial_eos.values)...)
 end
 function (::ExpandConfig)(pressures::Pressures)
-    unit = @u_str(pressures.unit)
+    unit = myuparse(pressures.unit)
     expanded = pressures.values .* unit
     if minimum(expanded) >= zero(eltype(expanded))  # values may have eltype `Any`
         @warn "for better fitting result, provide at least 1 negative pressure!"
@@ -120,7 +119,7 @@ function (::ExpandConfig)(pressures::Pressures)
     return expanded
 end
 function (::ExpandConfig)(volumes::Volumes)
-    unit = @u_str(volumes.unit)
+    unit = myuparse(volumes.unit)
     return volumes.values .* unit
 end
 function (::ExpandConfig{T})(files::IOFiles, fixed::Union{Pressures,Volumes}) where {T}

--- a/src/Express.jl
+++ b/src/Express.jl
@@ -7,6 +7,10 @@ import Unitful
 
 import Configurations: convert_to_option
 
+myuparse(str::AbstractString) =
+    uparse(filter(!isspace, str); unit_context = [Unitful, UnitfulAtomic])
+myuparse(num::Number) = num  # FIXME: this might be error-prone!
+
 abstract type Calculation end
 abstract type ElectronicStructure <: Calculation end
 struct SelfConsistentField <: ElectronicStructure end

--- a/src/Express.jl
+++ b/src/Express.jl
@@ -7,9 +7,7 @@ import Unitful
 
 import Configurations: convert_to_option
 
-myuparse(str::AbstractString) =
-    uparse(filter(!isspace, str); unit_context = Unitful.unitmodules)
-myuparse(num::Number) = num  # FIXME: this might be error-prone!
+myuparse(str::AbstractString) = uparse(str; unit_context = Unitful.unitmodules)
 
 abstract type Calculation end
 abstract type ElectronicStructure <: Calculation end

--- a/src/Express.jl
+++ b/src/Express.jl
@@ -8,7 +8,7 @@ import Unitful
 import Configurations: convert_to_option
 
 myuparse(str::AbstractString) =
-    uparse(filter(!isspace, str); unit_context = [Unitful, UnitfulAtomic])
+    uparse(filter(!isspace, str); unit_context = Unitful.unitmodules)
 myuparse(num::Number) = num  # FIXME: this might be error-prone!
 
 abstract type Calculation end

--- a/src/PhononWorkflow/Config.jl
+++ b/src/PhononWorkflow/Config.jl
@@ -3,8 +3,8 @@ module Config
 using AbInitioSoftwareBase.Commands: CommandConfig
 using Configurations: from_dict, @option
 using Formatting: sprintf1
-using Unitful: ustrip, @u_str
-using ...Express: Action, UnitfulVector
+using Unitful: ustrip
+using ...Express: Action, UnitfulVector, myuparse
 using ..PhononWorkflow: Scf, Dfpt, RealSpaceForceConstants, LatticeDynamics
 
 @option struct Template
@@ -82,7 +82,7 @@ end
 
 struct ExpandConfig{T} <: Action{T} end
 function (::ExpandConfig)(fixed::Union{Pressures,Volumes})
-    unit = @u_str(fixed.unit)
+    unit = myuparse(fixed.unit)
     return fixed.values .* unit
 end
 function (::ExpandConfig)(save::Save)

--- a/src/QuasiHarmonicApproxWorkflow/Config.jl
+++ b/src/QuasiHarmonicApproxWorkflow/Config.jl
@@ -3,7 +3,7 @@ module Config
 using AbInitioSoftwareBase: save, load, parentdir
 using Configurations: from_dict, @option
 using Unitful: ustrip, @u_str
-using ...Express: Action, UnitfulVector
+using ...Express: Action, UnitfulVector, myuparse
 
 @option struct Pressures <: UnitfulVector
     values::AbstractVector
@@ -20,7 +20,7 @@ end
     values::AbstractVector
     unit::String
     function Temperatures(values, unit = "K")
-        @assert minimum(values) * @u_str(unit) >= 0u"K" "the minimum temperature is less than 0K!"
+        @assert minimum(values) * myuparse(unit) >= 0u"K" "the minimum temperature is less than 0K!"
         return new(values, unit)
     end
 end
@@ -97,7 +97,7 @@ end
 
 struct ExpandConfig{T} <: Action{T} end
 function (::ExpandConfig)(pressures::Pressures)
-    unit = @u_str(pressures.unit)
+    unit = myuparse(pressures.unit)
     expanded = pressures.values .* unit
     if minimum(expanded) >= zero(eltype(expanded))  # values may have eltype `Any`
         @warn "for better fitting result, provide at least 1 negative pressure!"
@@ -105,7 +105,7 @@ function (::ExpandConfig)(pressures::Pressures)
     return expanded
 end
 function (::ExpandConfig)(temperatures::Temperatures)
-    unit = @u_str(temperatures.unit)
+    unit = myuparse(temperatures.unit)
     return temperatures.values .* unit
 end
 function (x::ExpandConfig)(config::AbstractDict)


### PR DESCRIPTION
Shouldn't deprecate `myuparse` because macros don't take variables